### PR TITLE
adds couchdb service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,13 +2,18 @@
 
 sudo chmod 1777 /tmp
 
+# update packages before starting service installs
+apt-get update
+
 for file in /u16all/version/*.sh;
 do
   . "$file"
 done
 
-# TODO: 
-#echo "================= Adding shippable_service ==================="
+echo "================= Adding shippable_service ==================="
+mkdir -p /usr/local/bin/shippable_services
+cp /u16all/services/* /usr/local/bin/shippable_services
+mv /usr/local/bin/shippable_services/shippable_service /usr/local/bin/shippable_service
 
 echo "================= Adding packages for shippable_service =================="
 apt install -y netcat

--- a/services/couchdb.sh
+++ b/services/couchdb.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+# Begin service ENV variables
+source "$(dirname "$0")/couchdb_env.sh"
+# End service ENV variables
+
+service_cmd=$1
+start_generic_service() {
+  name=$1
+  binary=$2
+  service_cmd=$3
+  service_port=$4
+
+
+  if [ -f "$binary" ]; then
+    sudo su -c "$service_cmd start > /dev/null 2>&1 &";
+    sleep 5
+
+    ## check if the service port is reachable
+    while ! nc -vz localhost "$service_port" &>/dev/null; do
+
+      ## check service process PID
+      service_proc=$(pgrep -f "$name" || echo "")
+
+      if [ ! -z "$service_proc" ]; then
+        ## service PID exists, service is starting. Hence wait...
+        echo "Waiting for $name to start...";
+      else
+        ## service PID does not exist, service crashed. Reboot service...
+        echo "Service $name boot error, restarting..."
+        sudo su -c "$service_cmd > /dev/null 2>&1 &";
+      fi
+      sleep 5;
+    done
+    echo "$name started successfully";
+  else
+    echo "$name will not be started because the binary was not found at $binary."
+    exit 99
+ fi
+}
+
+if [ "$service_cmd" = 'start' ]
+then
+  echo "================= Starting Couchdb ==================="
+  printf "\n"
+  start_generic_service "couchdb" "$SHIPPABLE_COUCHDB_BINARY" "$SHIPPABLE_COUCHDB_CMD" "$SHIPPABLE_COUCHDB_PORT" "$SHIPPABLE_COUCHDB_LOG";
+  printf "\n\n"
+elif [ "$service_cmd" = 'stop' ]
+then
+  echo "================= Stopping Couchdb ==================="
+  printf "\n"
+  su -c "$SHIPPABLE_COUCHDB_CMD stop";
+  printf "\n\n"
+else
+  echo "Failed to execute the action"
+fi
+

--- a/services/couchdb_env.sh
+++ b/services/couchdb_env.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+# Begin service ENV variables
+if [ -z "$SHIPPABLE_COUCHDB_PORT" ]; then
+  export SHIPPABLE_COUCHDB_PORT=5984;
+fi
+
+if [ -z "$SHIPPABLE_COUCHDB_BINARY" ]; then
+  export SHIPPABLE_COUCHDB_BINARY="/usr/bin/couchdb";
+fi
+
+if [ -z "$SHIPPABLE_COUCHDB_CMD" ]; then
+  export SHIPPABLE_COUCHDB_CMD="service couchdb";
+fi
+
+if [ -z "$SHIPPABLE_COUCHDB_LOG" ]; then
+  export SHIPPABLE_COUCHDB_LOG="couchdb.stderr";
+fi
+
+# End service ENV variables
+

--- a/services/shippable_service
+++ b/services/shippable_service
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+service_name=$1
+service_action=$2
+script_dir=$(dirname "$0")
+services_dir="$script_dir/shippable_services"
+
+if [ "$service_name" == "" ] || [ "$service_action" == "" ]; then
+  echo "Usage: shippable_service SERVICE COMMAND"
+  exit 1
+fi
+
+service_script="$services_dir/$service_name.sh"
+if [ ! -f "$service_script" ]; then
+  echo "Unknown service: $service_name"
+  exit 1
+fi
+
+if  [ "$service_action" != "start" ] &&  [ "$service_action" != "stop" ]; then
+  echo "Unknown service command: $service_action"
+  exit 1
+fi
+
+"$service_script" "$service_action"
+

--- a/test/service_test.sh
+++ b/test/service_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+declare -a services=( 'cassandra' 'couchdb' 'elasticsearch' 'memcached' 'mongodb' 'mysql' 'neo4j' 'postgres' 'rabbitmq' 'redismq' 'rethinkdb' 'riak' 'selenium')
+
+for service in "${services[@]}"
+  do
+	echo "Starting $service"
+	./shippable_services $service start
+	
+	echo "Stopping $service"
+	./shippable_services $service stop
+done 
+

--- a/test/service_test.sh
+++ b/test/service_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-declare -a services=( 'cassandra' 'couchdb' 'elasticsearch' 'memcached' 'mongodb' 'mysql' 'neo4j' 'postgres' 'rabbitmq' 'redismq' 'rethinkdb' 'riak' 'selenium')
+declare -a services=( 'couchdb') 
 
 for service in "${services[@]}"
   do

--- a/version/couchdb.sh
+++ b/version/couchdb.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+VERSION=1.6.0
+echo "================= Installing CouchDB $VERSION ==================="
+sudo apt-get install couchdb="$VERSION"* couchdb-bin="$VERSION"* couchdb-common="$VERSION"* -yf
+


### PR DESCRIPTION
https://github.com/dry-dock-aarch64/u16all/issues/3

couchdb is installed correctly
```
root@57b89e286f8a:/# couchdb version
Apache CouchDB 1.6.0 (LogLevel=info) is starting.
Apache CouchDB has started. Time to relax.
[info] [<0.32.0>] Apache CouchDB has started on http://127.0.0.1:5984/
```

will fix issues with `shippable_service couchdb start`  in the next PR