### PR TITLE
add neo4j service

### DIFF
--- a/services/neo4j.sh
+++ b/services/neo4j.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -e
+# Begin service ENV variables
+source "$(dirname "$0")/neo4j_env.sh"
+# End service ENV variables
+
+start_generic_service() {
+  name=$1
+  binary=$2
+  service_cmd=$3
+  service_port=$4
+
+
+  if [ -f "$binary" ]; then
+    sudo su -c "$service_cmd > /dev/null 2>&1 &";
+    sleep 5
+
+    ## check if the service port is reachable
+    while ! nc -vz localhost "$service_port" &>/dev/null; do
+
+      ## check service process PID
+      service_proc=$(pgrep -f "$binary" || echo "")
+
+      if [ ! -z "$service_proc" ]; then
+        ## service PID exists, service is starting. Hence wait...
+        echo "Waiting for $name to start...";
+      else
+        ## service PID does not exist, service crashed. Reboot service...
+        echo "Service $name boot error, restarting..."
+        sudo su -c "$service_cmd > /dev/null 2>&1 &";
+      fi
+      sleep 5;
+    done
+    echo "$name started successfully";
+  else
+    echo "$name will not be started because the binary was not found at $binary."
+    exit 99
+  fi
+}
+if [ "$1" = "start" ]
+then
+  echo "================= Starting neo4j ==================="
+  printf "\n"
+  start_generic_service "neo4j" "$SHIPPABLE_NEO4J_BINARY" "$SHIPPABLE_NEO4J_CMD" "$SHIPPABLE_NEO4J_PORT" "$SHIPPABLE_NEO4J_LOG";
+
+elif [ "$1" = "stop" ]
+then
+  echo "================= Stopping neo4j ==================="
+  printf "\n"
+ su -c "$SHIPPABLE_NEO4J_BINARY stop 2>&1 > /dev/null &";
+else
+  echo "No action executed"
+fi
+

--- a/services/neo4j_env.sh
+++ b/services/neo4j_env.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+# Begin service ENV variables
+
+if [ -z "$SHIPPABLE_NEO4J_PORT" ]; then
+  export SHIPPABLE_NEO4J_PORT=7474;
+fi
+
+if [ -z "$SHIPPABLE_NEO4J_BINARY" ]; then
+  export SHIPPABLE_NEO4J_BINARY="/var/lib/neo4j/bin/neo4j";
+fi
+
+if [ -z "$SHIPPABLE_NEO4J_CMD" ]; then
+  export SHIPPABLE_NEO4J_CMD="$SHIPPABLE_NEO4J_BINARY start";
+fi
+
+if [ -z "$SHIPPABLE_NEO4J_LOG" ]; then
+  export SHIPPABLE_NEO4J_LOG="/var/log/neo4j/neo4j.log"
+fi
+
+# End service ENV variables
+

--- a/test/service_test.sh
+++ b/test/service_test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -e
 
-declare -a services=( 'couchdb') 
+declare -a services=( 'couchdb', 'neo4j')
 
 for service in "${services[@]}"
   do
 	echo "Starting $service"
-	./shippable_services $service start
+	shippable_service $service start
 	
 	echo "Stopping $service"
-	./shippable_services $service stop
+	shippable_service $service stop
 done 
 

--- a/version/neo4j.sh
+++ b/version/neo4j.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+NEO4J_VERSION=3.3.1
+echo "=========== Installing neo4j $NEO4J_VERSION ============="
+
+NEO4J_TARBALL=neo4j-community-"$NEO4J_VERSION"-unix.tar.gz
+NEO4J_URI=https://neo4j.com/artifact.php?name=neo4j-community-"$NEO4J_VERSION"-unix.tar.gz
+
+curl --fail --show-error -o ${NEO4J_TARBALL} ${NEO4J_URI} \
+    && tar --extract --file ${NEO4J_TARBALL} --directory /var/lib \
+    && mv /var/lib/neo4j-* /var/lib/neo4j \
+    && rm ${NEO4J_TARBALL}
+


### PR DESCRIPTION
https://github.com/dry-dock-aarch64/u16all/issues/5

```
root@18b0c88b187a:/# shippable_service neo4j start
================= Starting neo4j ===================

Service neo4j boot error, restarting...
Service neo4j boot error, restarting...
Service neo4j boot error, restarting...
neo4j started successfully



root@18b0c88b187a:/# ps aux | grep neo4j
root       276  204  2.4 50858528 3259360 ?    Sl   11:59   0:59 /usr/bin/java -cp /var/lib/neo4j/plugins:/var/lib/neo4j/conf:/var/lib/neo4j/lib/*:/var/lib/neo4j/plugins/* -server -XX:+UseG1GC -XX:-OmitStackTraceInFastThrow -XX:+AlwaysPreTouch -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields -XX:+DisableExplicitGC -Djdk.tls.ephemeralDHKeySize=2048 -Dunsupported.dbms.udc.source=tarball -Dfile.encoding=UTF-8 org.neo4j.server.CommunityEntryPoint --home-dir=/var/lib/neo4j --config-dir=/var/lib/neo4j/conf
root      1150  0.0  0.0   2608   556 ?        S+   12:00   0:00 grep --color=auto neo4j


root@18b0c88b187a:/# curl localhost:7474
{
  "management" : "http://localhost:7474/db/manage/",
  "data" : "http://localhost:7474/db/data/",
  "bolt" : "bolt://localhost:7687"
}


root@18b0c88b187a:/# shippable_service neo4j stop
================= Stopping neo4j ===================

```