### PR TITLE
adds sqlite support

### DIFF
--- a/version/sqlite.sh
+++ b/version/sqlite.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+
+SQLITE_VERSION=3.11.0
+echo "================= Installing SQLite $SQLITE_VERSION ==================="
+
+apt-get install sqlite3="$SQLITE_VERSION"*
+


### PR DESCRIPTION
https://github.com/dry-dock-aarch64/u16all/issues/15

**we don't support sqlite as a shippable service, only add sqlite3 binary** 

```
root@mohit-dev:~/drydock/u16all-1# docker run -it niranjanhub/u16all:master

root@b46f63171b65:/# sqlite3 -version
3.11.0 2016-02-15 17:29:24 3d862f207e3adc00f78066799ac5a8c282430a5f

root@b46f63171b65:/# sqlite3
SQLite version 3.11.0 2016-02-15 17:29:24
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
sqlite> .quit


root@b46f63171b65:/# exit
exit

```