### PR TITLE
adds rabbitmq service

### DIFF
--- a/services/rabbitmq.sh
+++ b/services/rabbitmq.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -e
+# Begin service ENV variables
+source "$(dirname "$0")/rabbitmq_env.sh"
+# End service ENV variables
+
+start_generic_service() {
+  name=$1
+  binary=$2
+  service_cmd=$3
+  service_port=$4
+
+
+  if [ -f "$binary" ]; then
+    sudo su -c "$service_cmd > /dev/null 2>&1 &";
+    sleep 5
+
+    ## check if the service port is reachable
+    while ! nc -vz localhost "$service_port" &>/dev/null; do
+
+      ## check service process PID
+      service_proc=$(pgrep -f "$binary" || echo "")
+
+      if [ ! -z "$service_proc" ]; then
+        ## service PID exists, service is starting. Hence wait...
+        echo "Waiting for $name to start...";
+      else
+        ## service PID does not exist, service crashed. Reboot service...
+        echo "Service $name boot error, restarting..."
+        sudo su -c "$service_cmd > /dev/null 2>&1 &";
+      fi
+      sleep 5;
+    done
+    echo "$name started successfully";
+  else
+    echo "$name will not be started because the binary was not found at $binary."
+    exit 99  
+  fi
+}
+if [ "$1" = "start" ]
+then
+  echo "================= Starting rabbitmq ==================="
+  printf "\n"
+  start_generic_service "rabbitmq" "$SHIPPABLE_RABBITMQ_BINARY" "$SHIPPABLE_RABBITMQ_CMD" "$SHIPPABLE_RABBITMQ_PORT";
+elif [ "$1" = "stop" ]
+then
+  echo "================= Stopping rabbitmq ==================="
+  printf "\n"
+  sudo -u rabbitmq rabbitmqctl shutdown
+else
+  echo "No action executed"
+fi
+

--- a/services/rabbitmq_env.sh
+++ b/services/rabbitmq_env.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+# Begin service ENV variables
+
+if [ -z "$SHIPPABLE_RABBITMQ_PORT" ]; then
+  export SHIPPABLE_RABBITMQ_PORT=5672;
+fi
+
+if [ -z "$SHIPPABLE_RABBITMQ_BINARY" ]; then
+  export SHIPPABLE_RABBITMQ_BINARY="/usr/sbin/rabbitmq-server";
+fi
+
+if [ -z "$SHIPPABLE_RABBITMQ_CMD" ]; then
+  export SHIPPABLE_RABBITMQ_CMD="$SHIPPABLE_RABBITMQ_BINARY";
+fi
+
+# End service ENV variables
+

--- a/test/service_test.sh
+++ b/test/service_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-declare -a services=( 'couchdb', 'neo4j', 'mongodb', 'selenium', 'redis')
+declare -a services=( 'couchdb', 'neo4j', 'mongodb', 'selenium', 'redis', 'rabbitmq')
 
 for service in "${services[@]}"
   do

--- a/version/rabbitmq.sh
+++ b/version/rabbitmq.sh
@@ -1,0 +1,11 @@
+
+echo "================= Installing RabbitMQ PreReqs ==================="
+sudo apt-get install -q -y erlang erlang-nox socat logrotate
+
+RABBITMQ_VER=3.6.14
+echo "================= Installing RabbitMQ $RABBITMQ_VER ==================="
+RABBITMQ_DEB="rabbitmq-server_$RABBITMQ_VER-1_all.deb"
+sudo wget https://www.rabbitmq.com/releases/rabbitmq-server/v"$RABBITMQ_VER"/"$RABBITMQ_DEB"
+sudo dpkg -i "$RABBITMQ_DEB"
+sudo rm -f "$RABBITMQ_DEB"
+


### PR DESCRIPTION
https://github.com/dry-dock-aarch64/u16all/issues/10

install same version as x86_64 as repo supports it

```
root@mohit-dev:~/drydock/u16all-1# docker run -it niranjanhub/u16all:master


root@9f20cfe6ca10:/# shippable_service rabbitmq start
================= Starting rabbitmq ===================

Waiting for rabbitmq to start...
rabbitmq started successfully


root@9f20cfe6ca10:/# ps aux | grep rabbitmq
root        59  0.0  0.0   1872  1252 ?        S    07:45   0:00 /bin/sh /usr/sbin/rabbitmq-server
root        68  0.0  0.0   4860  2524 ?        S    07:45   0:00 su rabbitmq -s /bin/sh -c /usr/lib/rabbitmq/bin/rabbitmq-server 
rabbitmq    69  0.0  0.0   1872   416 ?        Ss   07:45   0:00 sh -c /usr/lib/rabbitmq/bin/rabbitmq-server 
rabbitmq    70  0.1  0.0   1872  1120 ?        S    07:45   0:00 /bin/sh /usr/lib/rabbitmq/bin/rabbitmq-server
rabbitmq   146  0.0  0.0   4896  1592 ?        S    07:45   0:00 /usr/lib/erlang/erts-7.3/bin/epmd -daemon
rabbitmq   261 59.4  0.1 25793900 144304 ?     Sl   07:45   0:11 /usr/lib/erlang/erts-7.3/bin/beam.smp -W w -A 1024 -P 1048576 -t 5000000 -stbt db -zdbbl 128000 -K true -B i -- -root /usr/lib/erlang -progname erl .......
rabbitmq  1521  0.0  0.0   2452   444 ?        Ss   07:45   0:00 inet_gethost 4
rabbitmq  1522  0.0  0.0   2580  1292 ?        S    07:45   0:00 inet_gethost 4
root      1527  0.0  0.0   2608   540 ?        S+   07:45   0:00 grep --color=auto rabbitmq
 


root@9f20cfe6ca10:/# nc -vz localhost 5672
localhost [127.0.0.1] 5672 (amqp) open
 
root@9f20cfe6ca10:/# shippable_service rabbitmq stop
================= Stopping rabbitmq ===================

root@9f20cfe6ca10:/# rabbitmq-server -v

              RabbitMQ 3.6.14. Copyright (C) 2007-2017 Pivotal Software, Inc.
  ##  ##      Licensed under the MPL.  See http://www.rabbitmq.com/
  ##  ##
....
```