### PR TITLE
adds memcached service

### DIFF
--- a/services/memcached.sh
+++ b/services/memcached.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -e
+# Begin service ENV variables
+source "$(dirname "$0")/memcached_env.sh"
+# End service ENV variables
+service_cmd=$1
+start_generic_service() {
+  name=$1
+  binary=$2
+  service_cmd=$3
+  service_port=$4
+
+
+  if [ -f "$binary" ]; then
+    sudo su -c "$service_cmd > /dev/null 2>&1 &";
+    sleep 5
+
+    ## check if the service port is reachable
+    while ! nc -vz localhost "$service_port" &>/dev/null; do
+
+      ## check service process PID
+      service_proc=$(pgrep -f "$binary" || echo "")
+
+      if [ ! -z "$service_proc" ]; then
+        ## service PID exists, service is starting. Hence wait...
+        echo "Waiting for $name to start...";
+      else
+        ## service PID does not exist, service crashed. Reboot service...
+        echo "Service $name boot error, restarting..."
+        sudo su -c "$service_cmd > /dev/null 2>&1 &";
+      fi
+      sleep 5;
+    done
+    echo "$name started successfully";
+  else
+    echo "$name will not be started because the binary was not found at $binary."
+    exit 99
+  fi
+}
+
+if [ "$service_cmd" = 'start' ]
+then
+  echo "================= Starting Memcached ==================="
+  printf "\n"
+  start_generic_service "memcache" "$SHIPPABLE_MEMCACHED_BINARY" "$SHIPPABLE_MEMCACHED_CMD" "$SHIPPABLE_MEMCACHED_PORT";
+  printf "\n"
+elif [ "$service_cmd" = 'stop' ]
+then
+  echo "================= Stopping Memcached ==================="
+  printf "\n"
+  sudo su -c "killall memcached";
+  printf "\n\n"
+else
+  echo "Failed to execute the action"
+fi
+

--- a/services/memcached_env.sh
+++ b/services/memcached_env.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+# Begin service ENV variables
+
+if [ -z "$SHIPPABLE_MEMCACHED_PORT" ]; then
+  export SHIPPABLE_MEMCACHED_PORT=11211;
+fi
+
+if [ -z "$SHIPPABLE_MEMCACHED_BINARY" ]; then
+  export SHIPPABLE_MEMCACHED_BINARY="/usr/bin/memcached";
+fi
+
+if [ -z "$SHIPPABLE_MEMCACHED_CMD" ]; then
+  export SHIPPABLE_MEMCACHED_CMD="$SHIPPABLE_MEMCACHED_BINARY -d -u nobody -l 127.0.0.1 -p $SHIPPABLE_MEMCACHED_PORT";
+fi
+
+# End service ENV variables
+

--- a/test/service_test.sh
+++ b/test/service_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-declare -a services=( 'couchdb', 'neo4j', 'mongodb', 'selenium', 'redis', 'rabbitmq')
+declare -a services=( 'couchdb', 'neo4j', 'mongodb', 'selenium', 'redis', 'rabbitmq', 'memcached' )
 
 for service in "${services[@]}"
   do

--- a/version/memcached.sh
+++ b/version/memcached.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+MEM_VERSION=1.5.4
+LIB_VERSION=1.0.18
+
+echo "================= Installing MemCached Prereqs ==================="
+apt-get install -y libevent-dev libsasl2-dev
+
+echo "================= Installing Memcached and LibMemCached ==================="
+apt-get install memcached="$MEM_VESRION"* libmemcached11="$LIB_VERSION"*
+


### PR DESCRIPTION
https://github.com/dry-dock-aarch64/u16all/issues/6


checked service start and stop and service stats using [telnet](http://www.alphadevx.com/a/90-Accessing-Memcached-from-the-command-line)
```
root@ab7c72f0c4c4:/# shippable_service memcached start
================= Starting Memcached ===================

memcache started successfully

root@ab7c72f0c4c4:/# ps aux | grep memcached
nobody      91  0.0  0.0 306956  1856 ?        Ssl  08:31   0:00 /usr/bin/memcached -d -u nobody -l 127.0.0.1 -p 11211
root        99  0.0  0.0   2608   580 ?        S+   08:31   0:00 grep --color=auto memcached

root@ab7c72f0c4c4:/# nc -v localhost 11211
localhost [127.0.0.1] 11211 (?) open


```