### PR TITLE
addds elasticsearch service

### DIFF
--- a/services/elasticsearch.sh
+++ b/services/elasticsearch.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+# Begin service ENV variables
+source "$(dirname "$0")/elasticsearch_env.sh"
+# End service ENV variables
+
+service_cmd=$1
+start_generic_service() {
+  name=$1
+  binary=$2
+  service_cmd=$3
+  service_port=$4
+
+
+  if [ -f "$binary" ]; then
+    sudo su -c "$service_cmd > /dev/null 2>&1 &";
+    sleep 5
+
+    ## check if the service port is reachable
+    while ! nc -vz localhost "$service_port" &>/dev/null; do
+
+      ## check service process PID
+      service_proc=$(pgrep -f "$binary" || echo "")
+
+      if [ ! -z "$service_proc" ]; then
+        ## service PID exists, service is starting. Hence wait...
+        echo "Waiting for $name to start...";
+      else
+        ## service PID does not exist, service crashed. Reboot service...
+        echo "Service $name boot error, restarting..."
+        sudo su -c "$service_cmd > /dev/null 2>&1 &";
+      fi
+      sleep 5;
+    done
+    echo "$name started successfully";
+  else
+    echo "$name will not be started because the binary was not found at $binary."
+    exit 99
+  fi
+}
+
+if [ "$service_cmd" = 'start' ]
+then
+  echo "================= Starting Elasticsearch ==================="
+  printf "\n"
+  start_generic_service "elasticsearch" "$SHIPPABLE_ES_BINARY" "$SHIPPABLE_ES_CMD" "$SHIPPABLE_ES_PORT";
+elif [ "$service_cmd" = 'stop' ]
+then
+  echo "================= Stopping Elasticsearch ==================="
+  printf "\n"
+  # This script is also called elasticsearch. We need to make sure we don't kill
+  # ourselves
+  kill -9 $(ps aux | grep elasticsearch | grep -v shippable_service | awk '{print $2}')
+else
+  echo "Failed to execute the action"
+fi
+

--- a/services/elasticsearch_env.sh
+++ b/services/elasticsearch_env.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+# Begin service ENV variables
+if [ -z "$SHIPPABLE_ES_CLUSTER_NAME" ]; then
+  export SHIPPABLE_ES_CLUSTER_NAME="shippabletest";
+fi
+
+if [ -z "$SHIPPABLE_ES_PORT" ]; then
+  export SHIPPABLE_ES_PORT=9200;
+fi
+
+if [ -z "$SHIPPABLE_ES_BINARY" ]; then
+  export SHIPPABLE_ES_BINARY="/usr/local/bin/elasticsearch";
+fi
+
+if [ -z "$SHIPPABLE_ES_TMP" ]; then
+  export SHIPPABLE_ES_TMP="/usr/local/elasticsearch/tmp"
+fi
+
+if [ -z "$SHIPPABLE_ES_CMD" ]; then
+  export SHIPPABLE_ES_CMD="ES_JAVA_OPTS=\"-Djna.tmpdir=$SHIPPABLE_ES_TMP -Djava.io.tmpdir=$SHIPPABLE_ES_TMP\" $SHIPPABLE_ES_BINARY -Ecluster.name=$SHIPPABLE_ES_CLUSTER_NAME";
+fi
+
+# End service ENV variables
+

--- a/test/service_test.sh
+++ b/test/service_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-declare -a services=( 'couchdb', 'neo4j', 'mongodb', 'selenium', 'redis', 'rabbitmq', 'memcached' )
+declare -a services=( 'couchdb', 'neo4j', 'mongodb', 'selenium', 'redis', 'rabbitmq', 'memcached', 'elasticsearch')
 
 for service in "${services[@]}"
   do

--- a/version/elasticsearch.sh
+++ b/version/elasticsearch.sh
@@ -1,0 +1,53 @@
+#!/bin/bash -e 
+
+# ensure elasticsearch user exists
+useradd elasticsearch
+
+# grab gosu for easy step-down from root
+GOSU_VERSION=1.7
+wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)"
+wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc"
+export GNUPGHOME="$(mktemp -d)"
+gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu
+rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc
+chmod +x /usr/local/bin/gosu
+gosu nobody true
+
+ELASTICSEARCH_VERSION=6.1.1
+cd /usr/local/
+
+echo "================= Installing ElasticSearch $ELASTICSEARCH_VERSION ==================="
+sudo wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
+sudo tar xzf elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz -C /usr/local && sudo rm -f elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
+sudo mv elasticsearch-${ELASTICSEARCH_VERSION} elasticsearch
+cp /u16all/version/elasticsearch_utils/elasticsearch /usr/local/bin/
+
+mkdir -p /usr/local/elasticsearch/logs
+mkdir -p /usr/local/elasticsearch/tmp
+
+cd /usr/local/elasticsearch
+cp -r /u16all/version/elasticsearch_utils/config /usr/local/elasticsearch/config
+for path in \
+	./tmp \
+	./data \
+	./logs \
+	./config \
+	./config/scripts \
+; do \
+	mkdir -p "$path";
+	chown -R elasticsearch "$path";
+done
+
+
+
+# Drop root privileges if we are running elasticsearch
+# allow the container to be started with `--user`
+# Change the ownership of user-mutable directories to elasticsearch
+for path in \
+	/usr/local/elasticsearch/data \
+	/usr/local/elasticsearch/logs \
+; do
+	chown -R elasticsearch "$path"
+done
+

--- a/version/elasticsearch_utils/config/elasticsearch.yml
+++ b/version/elasticsearch_utils/config/elasticsearch.yml
@@ -1,0 +1,7 @@
+
+http.host: 0.0.0.0
+
+# Uncomment the following lines for a production cluster deployment
+#transport.host: 0.0.0.0
+#discovery.zen.minimum_master_nodes: 1
+

--- a/version/elasticsearch_utils/config/log4j2.properties
+++ b/version/elasticsearch_utils/config/log4j2.properties
@@ -1,0 +1,10 @@
+status = error
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console
+

--- a/version/elasticsearch_utils/elasticsearch
+++ b/version/elasticsearch_utils/elasticsearch
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+
+#make sure elasticsearch is installed at /usr/local/elasticsearch/bin/
+gosu elasticsearch /usr/local/elasticsearch/bin/elasticsearch $@
+


### PR DESCRIPTION
https://github.com/dry-dock-aarch64/u16all/issues/4

install same version as x86_64 u16all - version `v6.1.1`

```
root@8fe46fdb1e72:/# shippable_service elasticsearch start
================= Starting Elasticsearch ===================

Waiting for elasticsearch to start...
Waiting for elasticsearch to start...
Waiting for elasticsearch to start...
elasticsearch started successfully

root@8fe46fdb1e72:/# curl localhost:9200
{
  "name" : "ENo-riG",
  "cluster_name" : "shippabletest",
  "cluster_uuid" : "LhVPYJ-VTDmad59TlKZKfA",
  "version" : {
    "number" : "6.1.1",
    "build_hash" : "bd92e7f",
    "build_date" : "2017-12-17T20:23:25.338Z",
    "build_snapshot" : false,
    "lucene_version" : "7.1.0",
    "minimum_wire_compatibility_version" : "5.6.0",
    "minimum_index_compatibility_version" : "5.0.0"
  },
  "tagline" : "You Know, for Search"
}
root@8fe46fdb1e72:/# shippable_service elasticsearch stop
================= Stopping Elasticsearch ===================

/usr/local/bin/shippable_services/elasticsearch.sh: line 52: kill: (382) - No such process
root@8fe46fdb1e72:/# echo $?
0

root@8fe46fdb1e72:/# ps aux | grep elasticsearch ## service is terminated 
root       713  0.0  0.0   2608   592 ?        S+   09:37   0:00 grep --color=auto elasticsearch

```