### PR TITLE
adds neo4j properties

### DIFF
--- a/neo4j-server.properties
+++ b/neo4j-server.properties
@@ -1,0 +1,86 @@
+################################################################
+# Neo4j
+#
+# neo4j-server.properties - runtime operational settings
+#
+################################################################
+
+#***************************************************************
+# Server configuration
+#***************************************************************
+
+# location of the database directory
+org.neo4j.server.database.location=data/graph.db
+
+# Low-level graph engine tuning file
+org.neo4j.server.db.tuning.properties=conf/neo4j.properties
+
+# Let the webserver only listen on the specified IP. Default is localhost (only
+# accept local connections). Uncomment to allow any connection. Please see the
+# security section in the neo4j manual before modifying this.
+#org.neo4j.server.webserver.address=0.0.0.0
+
+# Require (or disable the requirement of) auth to access Neo4j
+dbms.security.auth_enabled=false
+
+#
+# HTTP Connector
+#
+
+# http port (for all data, administrative, and UI access)
+org.neo4j.server.webserver.port=7474
+
+#
+# HTTPS Connector
+#
+
+# Turn https-support on/off
+org.neo4j.server.webserver.https.enabled=true
+
+# https port (for all data, administrative, and UI access)
+org.neo4j.server.webserver.https.port=7473
+
+# Certificate location (auto generated if the file does not exist)
+org.neo4j.server.webserver.https.cert.location=conf/ssl/snakeoil.cert
+
+# Private key location (auto generated if the file does not exist)
+org.neo4j.server.webserver.https.key.location=conf/ssl/snakeoil.key
+
+# Internally generated keystore (don't try to put your own
+# keystore there, it will get deleted when the server starts)
+org.neo4j.server.webserver.https.keystore.location=data/keystore
+
+# Comma separated list of JAX-RS packages containing JAX-RS resources, one
+# package name for each mountpoint. The listed package names will be loaded
+# under the mountpoints specified. Uncomment this line to mount the
+# org.neo4j.examples.server.unmanaged.HelloWorldResource.java from
+# neo4j-server-examples under /examples/unmanaged, resulting in a final URL of
+# http://localhost:7474/examples/unmanaged/helloworld/{nodeId}
+#org.neo4j.server.thirdparty_jaxrs_classes=org.neo4j.examples.server.unmanaged=/examples/unmanaged
+
+
+#*****************************************************************
+# HTTP logging configuration
+#*****************************************************************
+
+# HTTP logging is disabled. HTTP logging can be enabled by setting this
+# property to 'true'.
+org.neo4j.server.http.log.enabled=false
+
+# Logging policy file that governs how HTTP log output is presented and
+# archived. Note: changing the rollover and retention policy is sensible, but
+# changing the output format is less so, since it is configured to use the
+# ubiquitous common log format
+org.neo4j.server.http.log.config=conf/neo4j-http-logging.xml
+
+
+#*****************************************************************
+# Administration client configuration
+#*****************************************************************
+
+# location of the servers round-robin database directory. Possible values:
+# - absolute path like /var/rrd
+# - path relative to the server working directory like data/rrd
+# - commented out, will default to the database data directory.
+org.neo4j.server.webadmin.rrdb.location=data/rrd
+

--- a/version/neo4j.sh
+++ b/version/neo4j.sh
@@ -11,3 +11,7 @@ curl --fail --show-error -o ${NEO4J_TARBALL} ${NEO4J_URI} \
     && mv /var/lib/neo4j-* /var/lib/neo4j \
     && rm ${NEO4J_TARBALL}
 
+
+echo "========================= adding neo4j conf properties ==========="
+mkdir -p /var/lib/neo4j/conf
+cd /u16all && cp -rf neo4j-server.properties /var/lib/neo4j/conf/


### PR DESCRIPTION
https://github.com/dry-dock-aarch64/u16all/issues/5

adds `neo4j-server.properties` similar to `u16all`
```
root@mohit-dev:~/drydock/u16all-1# docker run -it niranjanhub/u16all:master
root@67ca3928da4a:/# shippable_service neo4j start
================= Starting neo4j ===================

Service neo4j boot error, restarting...
Service neo4j boot error, restarting...
Service neo4j boot error, restarting...
neo4j started successfully
root@67ca3928da4a:/#   
root@67ca3928da4a:/# 
root@67ca3928da4a:/# curl localhost:7474
{
  "management" : "http://localhost:7474/db/manage/",
  "data" : "http://localhost:7474/db/data/",
  "bolt" : "bolt://localhost:7687"
}root@67ca3928da4a:/# 

root@67ca3928da4a:/# shippable_service neo4j stop 
================= Stopping neo4j ===================

root@67ca3928da4a:/# echo $?
0  
       
root@67ca3928da4a:/# ls /var/lib/neo4j/conf/neo4j-server.properties 
/var/lib/neo4j/conf/neo4j-server.properties

```