### PR TITLE
adds postgres service

### DIFF
--- a/pg_hba.cnf
+++ b/pg_hba.cnf
@@ -1,0 +1,102 @@
+# PostgreSQL Client Authentication Configuration File
+# ===================================================
+#
+# Refer to the "Client Authentication" section in the PostgreSQL
+# documentation for a complete description of this file.  A short
+# synopsis follows.
+#
+# This file controls: which hosts are allowed to connect, how clients
+# are authenticated, which PostgreSQL user names they can use, which
+# databases they can access.  Records take one of these forms:
+#
+# local      DATABASE  USER  METHOD  [OPTIONS]
+# host       DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostssl    DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+# hostnossl  DATABASE  USER  ADDRESS  METHOD  [OPTIONS]
+#
+# (The uppercase items must be replaced by actual values.)
+#
+# The first field is the connection type: "local" is a Unix-domain
+# socket, "host" is either a plain or SSL-encrypted TCP/IP socket,
+# "hostssl" is an SSL-encrypted TCP/IP socket, and "hostnossl" is a
+# plain TCP/IP socket.
+#
+# DATABASE can be "all", "sameuser", "samerole", "replication", a
+# database name, or a comma-separated list thereof. The "all"
+# keyword does not match "replication". Access to replication
+# must be enabled in a separate record (see example below).
+#
+# USER can be "all", a user name, a group name prefixed with "+", or a
+# comma-separated list thereof.  In both the DATABASE and USER fields
+# you can also write a file name prefixed with "@" to include names
+# from a separate file.
+#
+# ADDRESS specifies the set of hosts the record matches.  It can be a
+# host name, or it is made up of an IP address and a CIDR mask that is
+# an integer (between 0 and 32 (IPv4) or 128 (IPv6) inclusive) that
+# specifies the number of significant bits in the mask.  A host name
+# that starts with a dot (.) matches a suffix of the actual host name.
+# Alternatively, you can write an IP address and netmask in separate
+# columns to specify the set of hosts.  Instead of a CIDR-address, you
+# can write "samehost" to match any of the server's own IP addresses,
+# or "samenet" to match any address in any subnet that the server is
+# directly connected to.
+#
+# METHOD can be "trust", "reject", "md5", "password", "gss", "sspi",
+# "ident", "peer", "pam", "ldap", "radius" or "cert".  Note that
+# "password" sends passwords in clear text; "md5" is preferred since
+# it sends encrypted passwords.
+#
+# OPTIONS are a set of options for the authentication in the format
+# NAME=VALUE.  The available options depend on the different
+# authentication methods -- refer to the "Client Authentication"
+# section in the documentation for a list of which options are
+# available for which authentication methods.
+#
+# Database and user names containing spaces, commas, quotes and other
+# special characters must be quoted.  Quoting one of the keywords
+# "all", "sameuser", "samerole" or "replication" makes the name lose
+# its special character, and just match a database or username with
+# that name.
+#
+# This file is read on server startup and when the postmaster receives
+# a SIGHUP signal.  If you edit the file on a running system, you have
+# to SIGHUP the postmaster for the changes to take effect.  You can
+# use "pg_ctl reload" to do that.
+
+# Put your actual configuration here
+# ----------------------------------
+#
+# If you want to allow non-local connections, you need to add more
+# "host" records.  In that case you will also need to make PostgreSQL
+# listen on a non-local interface via the listen_addresses
+# configuration parameter, or via the -i or -h command line switches.
+
+
+
+
+# DO NOT DISABLE!
+# If you change this first entry you will need to make sure that the
+# database superuser can access the database using some other method.
+# Noninteractive access to all databases is required during automatic
+# maintenance (custom daily cronjobs, replication, and similar tasks).
+#
+# Database administrative login by Unix domain socket
+local   all             postgres                                trust
+host    all             postgres        127.0.0.1/32            trust
+host    all             postgres        ::1/128                 trust
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     peer
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            md5
+# IPv6 local connections:
+host    all             all             ::1/128                 md5
+# Allow replication connections from localhost, by a user with the
+# replication privilege.
+#local   replication     postgres                                peer
+#host    replication     postgres        127.0.0.1/32            md5
+#host    replication     postgres        ::1/128                 md5
+

--- a/services/postgres.sh
+++ b/services/postgres.sh
@@ -1,0 +1,56 @@
+#!/bin/bash -e
+# Begin service ENV variables
+source "$(dirname "$0")/postgres_env.sh"
+# End service ENV variables
+service_cmd=$1
+
+start_generic_service() {
+  name=$1
+  binary=$2
+  service_cmd=$3
+  service_port=$4
+
+
+  if [ -f "$binary" ]; then
+    sudo su -c "$service_cmd > /dev/null 2>&1 &";
+    sleep 5
+
+    ## check if the service port is reachable
+    while ! nc -vz localhost "$service_port" &>/dev/null; do
+
+      ## check service process PID
+      service_proc=$(pgrep -f "$binary" || echo "")
+
+      if [ ! -z "$service_proc" ]; then
+        ## service PID exists, service is starting. Hence wait...
+        echo "Waiting for $name to start...";
+      else
+        ## service PID does not exist, service crashed. Reboot service...
+        echo "Service $name boot error, restarting..."
+        sudo su -c "$service_cmd > /dev/null 2>&1 &";
+      fi
+      sleep 5;
+    done
+    echo "$name started successfully";
+  else
+    echo "$name will not be started because the binary was not found at $binary."
+    exit 1
+  fi
+}
+
+if [ "$service_cmd" = 'start' ]
+then
+  echo "================= Starting postgres ==================="
+  printf "\n"
+  start_generic_service "postgres" "$SHIPPABLE_POSTGRES_BINARY" "$SHIPPABLE_POSTGRES_CMD" "$SHIPPABLE_POSTGRES_PORT";
+  printf "\n\n"
+elif [ "$service_cmd" = 'stop' ]
+then
+  echo "================= Stopping postgres ==================="
+  printf "\n"
+  sleep 30 #why sleep before stopping
+  (kill -9 $(pgrep -f postgresql)) &
+  echo "service postgresql killed"
+  printf "\n\n"
+fi
+

--- a/services/postgres_env.sh
+++ b/services/postgres_env.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+# Begin service ENV variables
+
+if [ -z "$SHIPPABLE_START_POSTGRES" ]; then
+  export SHIPPABLE_START_POSTGRES=true;
+fi
+
+if [ -z "$SHIPPABLE_POSTGRES_PORT" ]; then
+  export SHIPPABLE_POSTGRES_PORT=5432;
+fi
+
+if [ -z "$SHIPPABLE_POSTGRES_VERSION" ]; then
+  export SHIPPABLE_POSTGRES_VERSION="9.5";
+fi
+
+if [ -z "$SHIPPABLE_POSTGRES_BINARY" ]; then
+  export SHIPPABLE_POSTGRES_BINARY="/usr/lib/postgresql/$SHIPPABLE_POSTGRES_VERSION/bin/postgres";
+fi
+
+if [ -z "$SHIPPABLE_POSTGRES_CMD" ]; then
+  export SHIPPABLE_POSTGRES_CMD="sudo -u postgres $SHIPPABLE_POSTGRES_BINARY -c config_file=/etc/postgresql/$SHIPPABLE_POSTGRES_VERSION/main/postgresql.conf";
+fi
+
+# End service ENV variables
+

--- a/test/service_test.sh
+++ b/test/service_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-declare -a services=( 'couchdb', 'neo4j', 'mongodb', 'selenium', 'redis', 'rabbitmq', 'memcached', 'elasticsearch')
+declare -a services=( 'couchdb', 'neo4j', 'mongodb', 'selenium', 'redis', 'rabbitmq', 'memcached', 'elasticsearch', 'postgres')
 
 for service in "${services[@]}"
   do

--- a/version/postgres.sh
+++ b/version/postgres.sh
@@ -1,0 +1,17 @@
+
+#!/bin/bash -e
+
+POSTGRES_VERSION=9.5
+echo "================= Installing Postgres $POSTGRES_VERSION ==================="
+apt-get install -y postgresql-"$POSTGRES_VERSION" postgresql-server-dev-"$POSTGRES_VERSION" postgis
+
+echo "================= Adding PostgreSQL cnf ==================="
+cp -rf /u16all/pg_hba.cnf /etc/postgresql/"$POSTGRES_VERSION"/main/pg_hba.conf
+
+mkdir /etc/ssl/private-copy
+mv /etc/ssl/private/* /etc/ssl/private-copy/
+rm -r /etc/ssl/private
+mv /etc/ssl/private-copy /etc/ssl/private
+chmod -R 0700 /etc/ssl/private
+chown -R postgres /etc/ssl/private
+


### PR DESCRIPTION
https://github.com/dry-dock-aarch64/u16all/issues/9

installs postgres-9.5 from ubuntu apt repository as postgres's apt repo doesn't support arm64. 
```
root@mohit-dev:~/drydock/u16all-1# docker run -it niranjanhub/u16all:master
root@58d49d77ebf6:/# shippable_service postgres start
================= Starting postgres ===================

postgres started successfully


root@58d49d77ebf6:/# curl localhost:5432
curl: (52) Empty reply from server

root@58d49d77ebf6:/# sudo -u postgres psql
psql (9.5.11)
Type "help" for help.

postgres=# create database testdb;
CREATE DATABASE
postgres=# \q

root@58d49d77ebf6:/# shippable_service postgres stop
================= Stopping postgres ===================
service postgresql killed


root@58d49d77ebf6:/# /usr/lib/postgresql/9.5/bin/postgres -V
postgres (PostgreSQL) 9.5.11

```